### PR TITLE
fix: forcing dotenv to use the right env file

### DIFF
--- a/.proxyrc.js
+++ b/.proxyrc.js
@@ -6,7 +6,7 @@
  * on localhost:1234 so we don't have to deal with CORS.
  *
  */
-require('dotenv').config()
+require('dotenv').config({ path: '.env.development'});
 const {createProxyMiddleware} = require("http-proxy-middleware");
 
 const API_HOST = process.env.WALLET_CONFIG_API_HOST;


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->
Forcing dotenv to use the right env file (.env.development) and not the default one (.env)

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This fix allows the local proxy server to start correctly with the right configuration

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Tested locally running the project with these steps:
- populating an .env.development file using the .env.example one
- yarn dev:env
- yarn start

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
