### PR TITLE
[CHK-2472] Canceled by user outcome when user aborts paypal flow

### DIFF
--- a/src/routes/models/routeModel.ts
+++ b/src/routes/models/routeModel.ts
@@ -15,7 +15,8 @@ export enum OUTCOME_ROUTE {
   GENERIC_ERROR = "1",
   AUTH_ERROR = "14",
   CONFLICT = "15",
-  SUCCESS = "0"
+  SUCCESS = "0",
+  CANCELED_BY_USER = "8"
 }
 
 export enum ROUTE_FRAGMENT {

--- a/src/routes/pm/Paypal.tsx
+++ b/src/routes/pm/Paypal.tsx
@@ -70,7 +70,7 @@ export default function PaypalPage() {
   }, []);
 
   const redirectWithError = () =>
-    utils.url.redirectWithOutcome(OUTCOME_ROUTE.GENERIC_ERROR);
+    utils.url.redirectWithOutcome(OUTCOME_ROUTE.CANCELED_BY_USER);
 
   const onError = React.useCallback(() => {
     setLoading(false);


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
<!--- Describe your changes in detail -->

- Added CANCELED_BY_USER = "8" to the OUTCOME_ROUTE enum
- using CANCELED_BY_USER when the user aborts the paypal flow

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We have a more specific outcome (CANCELED_BY_USER) rather than a generic one (GENERIC_ERROR)

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested manually using the local FE development server

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
