### PR TITLE
[CHK-3000] fix: removing unuseful src attribute from iframe

### DIFF
--- a/src/features/onboard/components/IframeCardField.tsx
+++ b/src/features/onboard/components/IframeCardField.tsx
@@ -78,7 +78,6 @@ export function IframeCardField(props: Props) {
           aria-labelledby={label}
           id={`frame_${id}`}
           seamless
-          src={src}
           style={styles.iframe}
         />
         <Box


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
src attribute removed from iframe in IframeCardField Component. It's unuseful because the attribute is added dynamically by the function setSrcOnIframe. This seems to fix a problem with the onAllFieldsLoaded event

#### List of Changes
<!--- Describe your changes in detail -->

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
